### PR TITLE
Fixes silently failing ValueError when zipping atom neighbor features

### DIFF
--- a/ocpmodels/datasets/gasdb.py
+++ b/ocpmodels/datasets/gasdb.py
@@ -213,7 +213,7 @@ class AtomicFeatureGenerator:
         dummy_distance, dummy_index = self.radius + 1, 0
         for neighbors in all_neighbors:
             try:
-                _, distances, indices, _ = list(zip(*neighbors))
+                _, distances, indices = list(zip(*neighbors))
                 distances = list(distances)
                 indices = list(indices)
             # If there are no neighbors


### PR DESCRIPTION
`neighbors` is a list of 3-tuples but was getting zipped and assigned to 4 separate lists.

This was causing neighbor indices and distances to be assigned default dummy values.