### PR TITLE
Implement an SKLearn-like trainer

### DIFF
--- a/ocpmodels/common/logger.py
+++ b/ocpmodels/common/logger.py
@@ -43,7 +43,7 @@ class WandBLogger(Logger):
             config=self.config,
             id=self.config["cmd"]["timestamp"],
             name=self.config["cmd"]["identifier"],
-            dir="logs/wandb",
+            dir=self.config["cmd"]["logs_dir"]
         )
 
     def watch(self, model):

--- a/ocpmodels/datasets/gasdb.py
+++ b/ocpmodels/datasets/gasdb.py
@@ -11,7 +11,7 @@ import ase.db
 import numpy as np
 import torch
 from pymatgen.io.ase import AseAtomsAdaptor
-from torch_geometric.data import Data, InMemoryDataset
+from torch_geometric.data import Data, InMemoryDataset, DataLoader
 
 from ..common.registry import registry
 from .base import BaseDataset
@@ -139,6 +139,10 @@ class Gasdb(BaseDataset):
             slices[key] = torch.tensor(slices[key], dtype=torch.long)
 
         return data, slices
+
+    def get_full_dataloader(self, batch_size):
+        data_loader = DataLoader(self, batch_size=batch_size)
+        return data_loader
 
 
 class AtomicFeatureGenerator:

--- a/ocpmodels/trainers/sktrainer.py
+++ b/ocpmodels/trainers/sktrainer.py
@@ -1,0 +1,93 @@
+import os
+import yaml
+import datetime
+import torch
+from ocpmodels.common.registry import registry
+from .base_trainer import BaseTrainer
+
+
+@registry.register_trainer("sktrainer")
+class SKTrainer(BaseTrainer):
+    '''
+    Extended version of `BaseTrainer` that wraps up some of the overhead for us
+    and calls out some of the arguments explicitly. The flow should be:
+        trainer = SKTrainer(*)
+        trainer.load_task(*)
+        trainer.load_model(*)
+        trainer.load_criterion(*)   # optional
+        trainer.load_optimizer(*)   # optional
+        trainer.train(*)
+        trainer.predict(*)          # optional
+    '''
+    def __init__(self, run_dir='.', is_debug=False, is_vis=False,
+                 print_every=100, seed=None, logger=None):
+        self.is_debug = is_debug
+        self.is_vis = is_vis
+        self.config['cmd'] = {'print_every': print_every, 'seed': seed, 'logger': logger}
+
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.load_seed_from_config()
+        self._create_subdirs(run_dir)
+
+    def _create_subdirs(self, run_dir):
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        self.cmd['checkpoint_dir'] = os.path.join(run_dir, "checkpoints", timestamp)
+        self.cmd['results_dir'] = os.path.join(run_dir, "results", timestamp)
+        self.cmd['logs_dir'] = os.path.join(run_dir, "logs", self.config["logger"], timestamp)
+        os.makedirs(self.cmd['checkpoint_dir'])
+        os.makedirs(self.cmd['results_dir'])
+        os.makedirs(self.cmd['logs_dir'])
+
+    def train(self, train_size, val_size, test_size):
+        self.assert_config()
+        self.config['train_size'] = train_size
+        self.config['val_size'] = val_size
+        self.config['test_size'] = test_size
+
+        print(yaml.dump(self.config, default_flow_style=False))
+        self.train()
+
+    def assert_config(self):
+        # required methods
+        for attribute in ['task', 'model']:
+            if attribute not in self.config:
+                raise RuntimeError('The %s has not yet been loaded. Please call '
+                                   'the load_%s method.' % (attribute, attribute))
+
+        # optional methods that fall back to defaults
+        if 'criterion' not in self:
+            self.load_criterion()
+        if 'optim' not in self.config:
+            self.load_optimizer()
+
+    def load_task(self, src, dataset, description, labels, metric, type_):
+        self.config['dataset'] = {'src': src}
+        self.config['task'] = {'dataset': dataset,
+                               'description': description,
+                               'labels': labels,
+                               'metric': metric,
+                               'type': type_}
+        super(SKTrainer, self).load_task()
+
+    def load_model(self, model):
+        self.config['model'] = model
+        super(SKTrainer, self).load_model()
+
+    def load_optimizer(self, batch_size=64, lr_gamma=0.1, lr_initial=0.001,
+                       lr_milestones=None, max_exochs=50, warmup_epochs=10,
+                       warmup_factor=0.2):
+        # default for mutable object
+        if lr_milestones is None:
+            lr_milestones = [100, 150]
+
+        self.config['optim'] = {'batch_size': batch_size,
+                                'lr_gamma': lr_gamma,
+                                'lr_initial': lr_initial,
+                                'lr_milestones': lr_milestones,
+                                'max_exochs': max_exochs,
+                                'warmup_epochs': warmup_epochs,
+                                'warmup_factor': warmup_factor}
+        super(SKTrainer, self).load_optimizer()
+
+    def predict(self):
+        raise NotImplementedError

--- a/ocpmodels/trainers/sktrainer.py
+++ b/ocpmodels/trainers/sktrainer.py
@@ -10,8 +10,10 @@ from .base_trainer import BaseTrainer
 @registry.register_trainer("sktrainer")
 class SKTrainer(BaseTrainer):
     def __init__(self, task, model, dataset, optimizer, identifier,
-                 run_dir=".", is_debug=False, is_vis=False,
+                 run_dir=None, is_debug=False, is_vis=False,
                  print_every=100, seed=None, logger="wandb"):
+        if run_dir is None:
+            run_dir = os.getcwd()
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
         self.config = {"task": task,
@@ -26,7 +28,7 @@ class SKTrainer(BaseTrainer):
                                "timestamp": timestamp,
                                "checkpoint_dir": os.path.join(run_dir, "checkpoints", timestamp),
                                "results_dir": os.path.join(run_dir, "results", timestamp),
-                               "logs_dir": os.path.join(run_dir, "logs", logger, timestamp)}}
+                               "logs_dir": os.path.join(run_dir, "logs", timestamp)}}
 
         os.makedirs(self.config["cmd"]["checkpoint_dir"])
         os.makedirs(self.config["cmd"]["results_dir"])

--- a/ocpmodels/trainers/sktrainer.py
+++ b/ocpmodels/trainers/sktrainer.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 import yaml
 import datetime
 import torch
@@ -8,86 +9,35 @@ from .base_trainer import BaseTrainer
 
 @registry.register_trainer("sktrainer")
 class SKTrainer(BaseTrainer):
-    '''
-    Extended version of `BaseTrainer` that wraps up some of the overhead for us
-    and calls out some of the arguments explicitly. The flow should be:
-        trainer = SKTrainer(*)
-        trainer.load_task(*)
-        trainer.load_model(*)
-        trainer.load_criterion(*)   # optional
-        trainer.load_optimizer(*)   # optional
-        trainer.train(*)
-        trainer.predict(*)          # optional
-    '''
-    def __init__(self, run_dir='.', is_debug=False, is_vis=False,
-                 print_every=100, seed=None, logger=None):
+    def __init__(self, task, model, dataset, optimizer, identifier,
+                 run_dir=".", is_debug=False, is_vis=False,
+                 print_every=100, seed=None, logger="wandb"):
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+
+        self.config = {"task": task,
+                       "dataset": dataset,
+                       "model": model.pop("name"),
+                       "model_attributes": model,
+                       "optim": optimizer,
+                       "logger": logger,
+                       "cmd": {"identifier": identifier,
+                               "print_every": print_every,
+                               "seed": seed,
+                               "timestamp": timestamp,
+                               "checkpoint_dir": os.path.join(run_dir, "checkpoints", timestamp),
+                               "results_dir": os.path.join(run_dir, "results", timestamp),
+                               "logs_dir": os.path.join(run_dir, "logs", logger, timestamp)}}
+
+        os.makedirs(self.config["cmd"]["checkpoint_dir"])
+        os.makedirs(self.config["cmd"]["results_dir"])
+        os.makedirs(self.config["cmd"]["logs_dir"])
+
         self.is_debug = is_debug
         self.is_vis = is_vis
-        self.config['cmd'] = {'print_every': print_every, 'seed': seed, 'logger': logger}
-
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        self.load_seed_from_config()
-        self._create_subdirs(run_dir)
 
-    def _create_subdirs(self, run_dir):
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        self.cmd['checkpoint_dir'] = os.path.join(run_dir, "checkpoints", timestamp)
-        self.cmd['results_dir'] = os.path.join(run_dir, "results", timestamp)
-        self.cmd['logs_dir'] = os.path.join(run_dir, "logs", self.config["logger"], timestamp)
-        os.makedirs(self.cmd['checkpoint_dir'])
-        os.makedirs(self.cmd['results_dir'])
-        os.makedirs(self.cmd['logs_dir'])
-
-    def train(self, train_size, val_size, test_size):
-        self.assert_config()
-        self.config['train_size'] = train_size
-        self.config['val_size'] = val_size
-        self.config['test_size'] = test_size
-
+        self.load()
         print(yaml.dump(self.config, default_flow_style=False))
-        self.train()
-
-    def assert_config(self):
-        # required methods
-        for attribute in ['task', 'model']:
-            if attribute not in self.config:
-                raise RuntimeError('The %s has not yet been loaded. Please call '
-                                   'the load_%s method.' % (attribute, attribute))
-
-        # optional methods that fall back to defaults
-        if 'criterion' not in self:
-            self.load_criterion()
-        if 'optim' not in self.config:
-            self.load_optimizer()
-
-    def load_task(self, src, dataset, description, labels, metric, type_):
-        self.config['dataset'] = {'src': src}
-        self.config['task'] = {'dataset': dataset,
-                               'description': description,
-                               'labels': labels,
-                               'metric': metric,
-                               'type': type_}
-        super(SKTrainer, self).load_task()
-
-    def load_model(self, model):
-        self.config['model'] = model
-        super(SKTrainer, self).load_model()
-
-    def load_optimizer(self, batch_size=64, lr_gamma=0.1, lr_initial=0.001,
-                       lr_milestones=None, max_exochs=50, warmup_epochs=10,
-                       warmup_factor=0.2):
-        # default for mutable object
-        if lr_milestones is None:
-            lr_milestones = [100, 150]
-
-        self.config['optim'] = {'batch_size': batch_size,
-                                'lr_gamma': lr_gamma,
-                                'lr_initial': lr_initial,
-                                'lr_milestones': lr_milestones,
-                                'max_exochs': max_exochs,
-                                'warmup_epochs': warmup_epochs,
-                                'warmup_factor': warmup_factor}
-        super(SKTrainer, self).load_optimizer()
 
     def predict(self):
         raise NotImplementedError


### PR DESCRIPTION
Wraps up some of the overhead of folder/config management. Now we can pass all the arguments as a dictionary instead of a yaml. It also adds a `.predict` method to the trainer so we can pass in new data to predict on. Here's an example of the usage:

```
from ocpmodels.trainers.sktrainer import SKTrainer


task = {'dataset': 'gasdb',
        'description': 'Binding energy regression on a dataset of DFT results for CO, H, N, O, and OH adsorption on various slabs.',
        'labels': ['binding energy'],
        'metric': 'mae',
        'type': 'regression'}

model = {'name': 'cgcnn',
         'atom_embedding_size': 64,
         'fc_feat_size': 128,
         'num_fc_layers': 4,
         'num_graph_conv_layers': 6}

dataset = {'src': 'path_to_src',
           'train_size': 640,
           'val_size': 160,
           'test_size': 200}

optimizer = {'batch_size': 64,
             'lr_gamma': 0.1,
             'lr_initial': 0.001,
             'lr_milestones': [100, 150],
             'max_epochs': 50,
             'warmup_epochs': 10,
             'warmup_factor': 0.2}

trainer = SKTrainer(task=task,
                    model=model,
                    dataset=dataset,
                    optimizer=optimizer,
                    identifier='test_sktrainer')

trainer.train()

predictions = trainer.predict('path_to_new_src')
```