### PR TITLE
Create environment files for GPU dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Also related to [Graph Attention Networks](https://arxiv.org/abs/1710.10903) and
 
 ##  Installation
 
-[last updated May 21, 2020]
+[last updated June 3, 2020]
 
 The easiest way of installing prerequisites is via [conda](https://conda.io/docs/index.html).
 After installing [conda](http://conda.pydata.org/), run the following commands
@@ -18,36 +18,13 @@ to create a new [environment](https://conda.io/docs/user-guide/tasks/manage-envi
 named `ocp-models` and install dependencies:
 
 ### Pre-install step
+
 Install `conda-merge`:
 ```bash
 pip install conda-merge
 ```
 If you're using system `pip`, then you may want to add the `--user` flag to avoid using `sudo`.
-Check that you can invoke `conda-merge`:
-```
-$ conda-merge -h
-usage: conda-merge [-h] files [files ...]
-
-Tool to merge environment files of the conda package manager.
-
-Given a list of environment files, print a unified environment file.
-Usage: conda-merge file1 file2 ... [> unified-environment]
-
-Merge strategy for each part of the definition:
-  name: keep the last name, if any is given (according to the order of the files).
-  channels: merge the channel priorities of all files and keep each file's priorities
-    in the same order. If there is a collision between files, report an error.
-  dependencies: merge the dependencies and remove duplicates, sorts alphabetically.
-    conda itself can handle cases like [numpy, numpy=1.7] gracefully so no need
-    to do that. You may beautify the dependencies by hand if you wish.
-    The script also doesn't detect collisions, relying on conda to point that out.
-
-positional arguments:
-  files
-
-optional arguments:
-  -h, --help  show this help message and exit
-```
+Check that you can invoke `conda-merge` by running `conda-merge -h`.
 
 ### GPU machines
 
@@ -81,18 +58,6 @@ conda env create -f env.yml
 conda activate ocp-models
 pre-commit install
 ```
-
-### Additional experiment-specific setup
-
-Append `env.extras.yml` to the `conda-merge` command, e.g. for CPU machines:
-```
-conda-merge env.common.yml env.cpu.yml env.extras.yml > env.yml
-```
-
-The extras contain:
-- [Kevin Tran](https://github.com/ktran9891)'s Convolution-Fed Gaussian Process
-  (CFGP) pipeline requires `gpytorch`, installable via `conda install gpytorch -c conda-forge`.
-- Hyperparameter optimization (HPO) requires `Tune`, installable via `pip install ray[tune]`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,39 +17,79 @@ After installing [conda](http://conda.pydata.org/), run the following commands
 to create a new [environment](https://conda.io/docs/user-guide/tasks/manage-environments.html)
 named `ocp-models` and install dependencies:
 
+### Pre-install step
+Install `conda-merge`:
+```bash
+pip install conda-merge
+```
+If you're using system `pip`, then you may want to add the `--user` flag to avoid using `sudo`.
+Check that you can invoke `conda-merge`:
+```
+$ conda-merge -h
+usage: conda-merge [-h] files [files ...]
+
+Tool to merge environment files of the conda package manager.
+
+Given a list of environment files, print a unified environment file.
+Usage: conda-merge file1 file2 ... [> unified-environment]
+
+Merge strategy for each part of the definition:
+  name: keep the last name, if any is given (according to the order of the files).
+  channels: merge the channel priorities of all files and keep each file's priorities
+    in the same order. If there is a collision between files, report an error.
+  dependencies: merge the dependencies and remove duplicates, sorts alphabetically.
+    conda itself can handle cases like [numpy, numpy=1.7] gracefully so no need
+    to do that. You may beautify the dependencies by hand if you wish.
+    The script also doesn't detect collisions, relying on conda to point that out.
+
+positional arguments:
+  files
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
+
 ### GPU machines
 
 Instructions are for PyTorch 1.4, CUDA 10.0 specifically.
 
-- `conda create -n ocp-models python=3.6`
-- `conda activate ocp-models`
-- `conda install pytorch=1.4 cudatoolkit=10.0 pyyaml pymatgen ase matplotlib tensorboard pre-commit tqdm -c pytorch -c conda-forge`
-- Check if PyTorch is installed with CUDA support:
-    - `python -c "import torch; print(torch.cuda.is_available())"` should return true
-- Add CUDA to `$PATH` and `$CPATH`
-    - `export PATH=/usr/local/cuda/bin:$PATH`
-    - `export CPATH=/usr/local/cuda/include:$CPATH`
-- Add CUDA to `$LD_LIBRARY_PATH`
-    - `export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH`
-    - `export DYLD_LIBRARY_PATH=/usr/local/cuda/lib:$DYLD_LIBRARY_PATH`
-- Ensure that PyTorch and system CUDA versions match
-    - `python -c "import torch; print(torch.version.cuda)"` and `nvcc --version` should both return 10.0
-- `pip install torch-scatter==latest+cu100 torch-sparse==latest+cu100 torch-cluster==latest+cu100 torch-spline-conv==latest+cu100 -f https://pytorch-geometric.com/whl/torch-1.4.0.html`
-- `pip install torch-geometric demjson wandb`
-- `pre-commit install`
+First, check that CUDA is in your `PATH` and `LD_LIBRARY_PATH`, e.g.
+```
+$ echo $PATH | tr ':' '\n' | grep cuda
+/public/apps/cuda/10.0/bin
+$ echo $LD_LIBRARY_PATH | tr ':' '\n' | grep cuda
+/public/apps/cuda/10.0/lib64
+```
+The exact paths may differ on your system. Then install the dependencies:
+```bash
+conda-merge env.common.yml env.gpu.yml > env.yml
+conda env create -f env.yml
+```
+Activate the conda environment with `conda activate ocp-models`.
+Finally, install the pre-commit hooks:
+```bash
+pre-commit install
+```
 
 ### CPU-only machines
 
 Please skip the following if you completed the with-GPU installation from above.
 
 ```bash
-conda env create -f env.cpu.yml
+conda-merge env.common.yml env.cpu.yml > env.yml
+conda env create -f env.yml
 conda activate ocp-models
 pre-commit install
 ```
 
 ### Additional experiment-specific setup
 
+Append `env.extras.yml` to the `conda-merge` command, e.g. for CPU machines:
+```
+conda-merge env.common.yml env.cpu.yml env.extras.yml > env.yml
+```
+
+The extras contain:
 - [Kevin Tran](https://github.com/ktran9891)'s Convolution-Fed Gaussian Process
   (CFGP) pipeline requires `gpytorch`, installable via `conda install gpytorch -c conda-forge`.
 - Hyperparameter optimization (HPO) requires `Tune`, installable via `pip install ray[tune]`.

--- a/env.common.yml
+++ b/env.common.yml
@@ -1,0 +1,20 @@
+name: ocp-models
+channels:
+  - pytorch
+  - conda-forge
+  - defaults
+dependencies:
+  - ase=3.19.*
+  - matplotlib=3.2.*
+  - pip
+  - pre-commit=2.2.*
+  - pymatgen=2020.4.2
+  - python=3.6.*
+  - pytorch=1.4.*
+  - pyyaml=5.3.*
+  - tensorboard=1.15.*
+  - tqdm=4.45.*
+  - pip:
+    - demjson
+    - torch-geometric==1.4.*
+    - wandb

--- a/env.common.yml
+++ b/env.common.yml
@@ -5,6 +5,7 @@ channels:
   - defaults
 dependencies:
   - ase=3.19.*
+  - gpytorch
   - matplotlib=3.2.*
   - pip
   - pre-commit=2.2.*
@@ -16,5 +17,7 @@ dependencies:
   - tqdm=4.45.*
   - pip:
     - demjson
+    - Pillow
+    - ray[tune]
     - torch-geometric==1.4.*
     - wandb

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -1,23 +1,6 @@
-name: ocp-models
-channels:
-  - pytorch
-  - conda-forge
-  - defaults
 dependencies:
-  - ase=3.19.1
-  - matplotlib=3.2.1
-  - pre-commit=2.2.0
-  - pymatgen=2020.4.2
-  - pytorch=1.5.0
-  - pyyaml=5.3.1
-  - tensorboard=1.15.0
-  - tqdm=4.45.0
   - pip:
-    - demjson
-    - torch-cluster==1.5.4
-    - torch-geometric==1.4.3
-    - torch-scatter==2.0.4
-    - torch-sparse==0.6.2
-    - torch-spline-conv==1.2.0
-    - wandb
-    - ray[tune]
+    - torch-cluster==1.5.*
+    - torch-scatter==2.0.*
+    - torch-sparse==0.6.*
+    - torch-spline-conv==1.2.*

--- a/env.extras.yml
+++ b/env.extras.yml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-dependencies:
-  - gpytorch
-  - pip:
-    - ray[tune]

--- a/env.extras.yml
+++ b/env.extras.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+dependencies:
+  - gpytorch
+  - pip:
+    - ray[tune]

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -1,0 +1,12 @@
+channels:
+  - pytorch
+  - conda-forge
+  - defaults
+dependencies:
+  - cudatoolkit=10.0
+  - pip:
+    - -f https://pytorch-geometric.com/whl/torch-1.4.0.html
+    - torch-cluster==latest+cu100
+    - torch-scatter==latest+cu100
+    - torch-sparse==latest+cu100
+    - torch-spline-conv==latest+cu100


### PR DESCRIPTION
Common dependencies were split out of `env.cpu.yml` into `env.common.yml`. GPU specific dependencies were put into `env.gpu.yml`. This allows the user to use `conda-merge` to create a final config which can be passed to `conda env create`, e.g.
```
conda-merge env.common.yml env.cpu.yml > env.yml
conda env create -f env.yml
```

Followed the updated instructions for testing to make sure envs were created without error