### PR TITLE
Converts ase atoms to batches without writing intermediate traj files during inference

### DIFF
--- a/ocpmodels/datasets/co_cu_md.py
+++ b/ocpmodels/datasets/co_cu_md.py
@@ -160,6 +160,7 @@ class COCuMD(BaseDataset):
 
         return train_loader, val_loader, test_loader
 
+    # This is primarily meant for evaluation, and so doesn't return targets.
     def ase_atoms_to_batch(self, atoms):
         generator = AtomicFeatureGenerator(None).extract_atom_features(atoms)
         embedding, distance, index, positions, atomic_numbers = generator
@@ -182,8 +183,6 @@ class COCuMD(BaseDataset):
                     pos=positions,
                     atomic_numbers=atomic_numbers,
                     natoms=torch.tensor([positions.shape[0]]),
-                    y=torch.tensor([0]),
-                    force=torch.tensor([0]),
                 )
             ]
         )

--- a/ocpmodels/datasets/co_cu_md.py
+++ b/ocpmodels/datasets/co_cu_md.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 from ase.io.trajectory import Trajectory
 from pymatgen.io.ase import AseAtomsAdaptor
-from torch_geometric.data import Data, DataLoader
+from torch_geometric.data import Batch, Data, DataLoader
 from tqdm import tqdm
 
 from ocpmodels.common.registry import registry
@@ -159,6 +159,36 @@ class COCuMD(BaseDataset):
             test_loader = DataLoader(test_dataset, batch_size=batch_size)
 
         return train_loader, val_loader, test_loader
+
+    def ase_atoms_to_batch(self, atoms):
+        generator = AtomicFeatureGenerator(None).extract_atom_features(atoms)
+        embedding, distance, index, positions, atomic_numbers = generator
+        edge_index = [[], []]
+        edge_attr = torch.FloatTensor(
+            index.shape[0] * index.shape[1], distance.shape[-1]
+        )
+        for j in range(index.shape[0]):
+            for k in range(index.shape[1]):
+                edge_index[0].append(j)
+                edge_index[1].append(index[j, k])
+                edge_attr[j * index.shape[1] + k] = distance[j, k].clone()
+        edge_index = torch.LongTensor(edge_index)
+        data = Batch.from_data_list(
+            [
+                Data(
+                    x=embedding,
+                    edge_index=edge_index,
+                    edge_attr=edge_attr,
+                    pos=positions,
+                    atomic_numbers=atomic_numbers,
+                    natoms=torch.tensor([positions.shape[0]]),
+                    y=torch.tensor([0]),
+                    force=torch.tensor([0]),
+                )
+            ]
+        )
+
+        return data
 
 
 class TrajectoryFeatureGenerator(AtomicFeatureGenerator):

--- a/ocpmodels/trainers/md_trainer.py
+++ b/ocpmodels/trainers/md_trainer.py
@@ -2,9 +2,10 @@ import datetime
 import os
 import warnings
 
+import torch
+import torch_geometric
 import yaml
 
-import torch
 from ocpmodels.common.meter import Meter
 from ocpmodels.common.registry import registry
 from ocpmodels.common.utils import plot_histogram, save_checkpoint
@@ -73,9 +74,9 @@ class MDTrainer(BaseTrainer):
 
     def load_task(self):
         print("### Loading dataset: {}".format(self.config["task"]["dataset"]))
-        dataset = registry.get_dataset_class(self.config["task"]["dataset"])(
-            self.config["dataset"]
-        )
+        self.dataset = registry.get_dataset_class(
+            self.config["task"]["dataset"]
+        )(self.config["dataset"])
         num_targets = 1
 
         self.num_targets = num_targets
@@ -83,7 +84,7 @@ class MDTrainer(BaseTrainer):
             self.train_loader,
             self.val_loader,
             self.test_loader,
-        ) = dataset.get_dataloaders(
+        ) = self.dataset.get_dataloaders(
             batch_size=self.config["optim"]["batch_size"]
         )
 
@@ -135,18 +136,21 @@ class MDTrainer(BaseTrainer):
             self.logger.log_plots(plots)
 
     # Takes in a new data source and generates predictions on it.
-    def predict(self, dataset_config, batch_size=32, verbose=True):
-        if verbose:
-            print(
-                "### Generating predictions on {}.".format(
-                    dataset_config["src"]
+    def predict(self, dataset, batch_size=32, verbose=True):
+        if isinstance(dataset, dict):
+            if verbose:
+                print(
+                    "### Generating predictions on {}.".format(dataset["src"])
                 )
-            )
 
-        dataset = registry.get_dataset_class(self.config["task"]["dataset"])(
-            dataset_config, mode="predict", verbose=verbose
-        )
-        data_loader = dataset.get_dataloaders(batch_size=batch_size)
+            dataset = registry.get_dataset_class(
+                self.config["task"]["dataset"]
+            )(dataset, mode="predict", verbose=verbose)
+            data_loader = dataset.get_dataloaders(batch_size=batch_size)
+        elif isinstance(dataset, torch_geometric.data.Batch):
+            data_loader = [dataset]
+        else:
+            raise NotImplementedError
 
         self.model.eval()
         predictions = {"energy": [], "forces": []}

--- a/ocpmodels/trainers/md_trainer.py
+++ b/ocpmodels/trainers/md_trainer.py
@@ -157,7 +157,7 @@ class MDTrainer(BaseTrainer):
 
         for i, batch in enumerate(data_loader):
             batch.to(self.device)
-            out, _ = self._forward(batch)
+            out, _ = self._forward(batch, compute_metrics=False)
             if self.normalizers is not None and "target" in self.normalizers:
                 out["output"] = self.normalizers["target"].denorm(
                     out["output"]


### PR DESCRIPTION
Speeds things up by a bit. A 300-step relaxation with CGCNN now takes about ~30 seconds compared to ~50 seconds earlier.