### PR TITLE
Added submitit support to run on slurm cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ Local
 
 # VIM swap files
 *.swp
+
+# PyCharm
+.idea/

--- a/configs/2020_07_13_ocp_reset_200k/schnet_sweep.yml
+++ b/configs/2020_07_13_ocp_reset_200k/schnet_sweep.yml
@@ -1,0 +1,7 @@
+
+model:
+  hidden_channels: [32, 64]
+  num_filters: [64, 128, 256]
+
+optim:
+  lr_initial: [0.01, 0.001, 0.0001]

--- a/env.common.yml
+++ b/env.common.yml
@@ -23,3 +23,4 @@ dependencies:
     - wandb
     - lmdb==0.98
     - pytest==5.4.3
+    - submitit

--- a/main.py
+++ b/main.py
@@ -1,14 +1,12 @@
+import submitit
+
 from ocpmodels.common.flags import flags
 from ocpmodels.common.registry import registry
 from ocpmodels.common.utils import build_config, setup_imports
 
-if __name__ == "__main__":
-    parser = flags.get_parser()
-    args = parser.parse_args()
 
+def main(config):
     setup_imports()
-    config = build_config(args)
-
     trainer = registry.get_trainer_class(config.get("trainer", "simple"))(
         task=config["task"],
         model=config["model"],
@@ -22,3 +20,26 @@ if __name__ == "__main__":
         logger=config.get("logger", "tensorboard"),
     )
     trainer.train()
+
+
+if __name__ == "__main__":
+    parser = flags.get_parser()
+    args = parser.parse_args()
+    config = build_config(args)
+
+    if args.submit:  # Run on cluster
+        executor = submitit.AutoExecutor(folder=args.logdir)
+        executor.update_parameters(
+            name=args.identifier,
+            mem_gb=args.slurm_mem,
+            timeout_min=args.slurm_timeout * 60,
+            slurm_partition=args.slurm_partition,
+            gpus_per_node=args.num_gpus,
+            cpus_per_task=(args.num_workers + 1),
+            ntasks_per_node=1,
+        )
+        job = executor.submit(main, config)
+        print('Submitted job:', job.job_id)
+
+    else:  # Run locally
+        main(config)

--- a/main.py
+++ b/main.py
@@ -2,7 +2,12 @@ import submitit
 
 from ocpmodels.common.flags import flags
 from ocpmodels.common.registry import registry
-from ocpmodels.common.utils import build_config, setup_imports, create_grid, save_experiment_log
+from ocpmodels.common.utils import (
+    build_config,
+    create_grid,
+    save_experiment_log,
+    setup_imports,
+)
 
 
 def main(config):
@@ -33,8 +38,8 @@ if __name__ == "__main__":
         else:
             configs = [config]
 
-        print(f'Submitting {len(configs)} jobs')
-        executor = submitit.AutoExecutor(folder=args.logdir / '%j')
+        print(f"Submitting {len(configs)} jobs")
+        executor = submitit.AutoExecutor(folder=args.logdir / "%j")
         executor.update_parameters(
             name=args.identifier,
             mem_gb=args.slurm_mem,
@@ -45,9 +50,9 @@ if __name__ == "__main__":
             tasks_per_node=1,
         )
         jobs = executor.map_array(main, configs)
-        print('Submitted jobs:', ', '.join([job.job_id for job in jobs]))
+        print("Submitted jobs:", ", ".join([job.job_id for job in jobs]))
         log_file = save_experiment_log(args, jobs, configs)
-        print(f'Experiment log saved to: {log_file}')
+        print(f"Experiment log saved to: {log_file}")
 
     else:  # Run locally
         main(config)

--- a/ocpmodels/common/flags.py
+++ b/ocpmodels/common/flags.py
@@ -54,6 +54,25 @@ class Flags:
         self.parser.add_argument(
             "--seed", default=0, type=int, help="Seed for torch, cuda, numpy"
         )
+        # Cluster args
+        self.parser.add_argument(
+            "--submit", action='store_true', help="Submit job to cluster"
+        )
+        self.parser.add_argument(
+            "--logdir", default='logs', type=str, help="Where to store logs"
+        )
+        self.parser.add_argument(
+            "--slurm-partition", default="dev", type=str, help="Name of partition"
+        )
+        self.parser.add_argument(
+            "--slurm-mem", default=80, type=int, help="Memory (in gigabytes)"
+        )
+        self.parser.add_argument(
+            "--slurm-timeout", default=72, type=int, help="Time (in hours)"
+        )
+        self.parser.add_argument(
+            "--num-gpus", default=1, type=int, help="Number of GPUs to request"
+        )
 
 
 flags = Flags()

--- a/ocpmodels/common/flags.py
+++ b/ocpmodels/common/flags.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 
+
 class Flags:
     def __init__(self):
         self.parser = argparse.ArgumentParser(
@@ -55,17 +56,22 @@ class Flags:
         )
         # Cluster args
         self.parser.add_argument(
-            "--sweep-yml", default=None, type=Path,
-            help="Path to a config file with parameter sweeps"
+            "--sweep-yml",
+            default=None,
+            type=Path,
+            help="Path to a config file with parameter sweeps",
         )
         self.parser.add_argument(
-            "--submit", action='store_true', help="Submit job to cluster"
+            "--submit", action="store_true", help="Submit job to cluster"
         )
         self.parser.add_argument(
-            "--logdir", default='logs', type=Path, help="Where to store logs"
+            "--logdir", default="logs", type=Path, help="Where to store logs"
         )
         self.parser.add_argument(
-            "--slurm-partition", default="dev", type=str, help="Name of partition"
+            "--slurm-partition",
+            default="dev",
+            type=str,
+            help="Name of partition",
         )
         self.parser.add_argument(
             "--slurm-mem", default=80, type=int, help="Memory (in gigabytes)"

--- a/ocpmodels/common/flags.py
+++ b/ocpmodels/common/flags.py
@@ -1,6 +1,5 @@
 import argparse
-import sys
-
+from pathlib import Path
 
 class Flags:
     def __init__(self):
@@ -56,10 +55,14 @@ class Flags:
         )
         # Cluster args
         self.parser.add_argument(
+            "--sweep-yml", default=None, type=Path,
+            help="Path to a config file with parameter sweeps"
+        )
+        self.parser.add_argument(
             "--submit", action='store_true', help="Submit job to cluster"
         )
         self.parser.add_argument(
-            "--logdir", default='logs', type=str, help="Where to store logs"
+            "--logdir", default='logs', type=Path, help="Where to store logs"
         )
         self.parser.add_argument(
             "--slurm-partition", default="dev", type=str, help="Name of partition"

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -255,7 +255,7 @@ def build_config(args):
 
 
 def create_grid(base_config, sweep_file):
-    def _flatten_sweeps(sweeps, root_key='', sep='.'):
+    def _flatten_sweeps(sweeps, root_key="", sep="."):
         flat_sweeps = []
         for key, value in sweeps.items():
             new_key = root_key + sep + key if root_key else key
@@ -265,7 +265,7 @@ def create_grid(base_config, sweep_file):
                 flat_sweeps.append((new_key, value))
         return collections.OrderedDict(flat_sweeps)
 
-    def _update_config(config, keys, override_vals, sep='.'):
+    def _update_config(config, keys, override_vals, sep="."):
         for key, value in zip(keys, override_vals):
             key_path = key.split(sep)
             child_config = config
@@ -283,23 +283,25 @@ def create_grid(base_config, sweep_file):
     for i, override_vals in enumerate(values):
         config = copy.deepcopy(base_config)
         config = _update_config(config, keys, override_vals)
-        config['identifier'] = config['identifier'] + f'_run{i}'
+        config["identifier"] = config["identifier"] + f"_run{i}"
         configs.append(config)
     return configs
 
 
 def save_experiment_log(args, jobs, configs):
-    log_file = args.logdir / 'exp' / time.strftime("%Y-%m-%d-%I-%M-%S%p.log")
+    log_file = args.logdir / "exp" / time.strftime("%Y-%m-%d-%I-%M-%S%p.log")
     log_file.parent.mkdir(exist_ok=True, parents=True)
-    with open(log_file, 'w') as f:
+    with open(log_file, "w") as f:
         for job, config in zip(jobs, configs):
             print(
-                json.dumps({
-                    "config": config,
-                    "slurm_id": job.job_id,
-                    "timestamp": time.strftime("%I:%M:%S%p %Z %b %d, %Y"),
-                }),
-                file=f
+                json.dumps(
+                    {
+                        "config": config,
+                        "slurm_id": job.job_id,
+                        "timestamp": time.strftime("%I:%M:%S%p %Z %b %d, %Y"),
+                    }
+                ),
+                file=f,
             )
     return log_file
 

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -1,7 +1,11 @@
+import collections
+import copy
 import glob
 import importlib
+import itertools
+import json
 import os
-import shutil
+import time
 from bisect import bisect
 from itertools import product
 
@@ -248,6 +252,56 @@ def build_config(args):
     config["print_every"] = args.print_every
 
     return config
+
+
+def create_grid(base_config, sweep_file):
+    def _flatten_sweeps(sweeps, root_key='', sep='.'):
+        flat_sweeps = []
+        for key, value in sweeps.items():
+            new_key = root_key + sep + key if root_key else key
+            if isinstance(value, collections.MutableMapping):
+                flat_sweeps.extend(_flatten_sweeps(value, new_key).items())
+            else:
+                flat_sweeps.append((new_key, value))
+        return collections.OrderedDict(flat_sweeps)
+
+    def _update_config(config, keys, override_vals, sep='.'):
+        for key, value in zip(keys, override_vals):
+            key_path = key.split(sep)
+            child_config = config
+            for name in key_path[:-1]:
+                child_config = child_config[name]
+            child_config[key_path[-1]] = value
+        return config
+
+    sweeps = yaml.safe_load(open(sweep_file, "r"))
+    flat_sweeps = _flatten_sweeps(sweeps)
+    keys = list(flat_sweeps.keys())
+    values = list(itertools.product(*flat_sweeps.values()))
+
+    configs = []
+    for i, override_vals in enumerate(values):
+        config = copy.deepcopy(base_config)
+        config = _update_config(config, keys, override_vals)
+        config['identifier'] = config['identifier'] + f'_run{i}'
+        configs.append(config)
+    return configs
+
+
+def save_experiment_log(args, jobs, configs):
+    log_file = args.logdir / 'exp' / time.strftime("%Y-%m-%d-%I-%M-%S%p.log")
+    log_file.parent.mkdir(exist_ok=True, parents=True)
+    with open(log_file, 'w') as f:
+        for job, config in zip(jobs, configs):
+            print(
+                json.dumps({
+                    "config": config,
+                    "slurm_id": job.job_id,
+                    "timestamp": time.strftime("%I:%M:%S%p %Z %b %d, %Y"),
+                }),
+                file=f
+            )
+    return log_file
 
 
 def get_pbc_distances(pos, edge_index, cell, cell_offsets, natoms):


### PR DESCRIPTION
The main.py script still works like before for local training. 

To train on the cluster, just add a `--submit`, for example:
```
python main.py --config-yml configs/2020_07_13_ocp_reset_200k/schnet.yml --seed 1 --submit
```

It is also possible to run a grid search by specifying the `--sweep-yml` argument:
```
python main.py --config-yml configs/2020_07_13_ocp_reset_200k/schnet.yml --seed 1 --submit --sweep-yml configs/2020_07_13_ocp_reset_200k/schnet_sweep.yml
```