### PR TITLE
preprocessing refactor: removes dummy indices, resolves pbc distance bug, cleans up pbc/dataloader utils.

### DIFF
--- a/ocpmodels/common/ase_utils.py
+++ b/ocpmodels/common/ase_utils.py
@@ -29,10 +29,8 @@ class OCPCalculator(Calculator):
         Calculator.__init__(self)
         self.trainer = trainer
         self.a2g = AtomsToGraphs(
-            max_neigh=12,
+            max_neigh=200,
             radius=6,
-            dummy_distance=7,
-            dummy_index=-1,
             r_energy=False,
             r_forces=False,
             r_distances=False,

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -319,4 +319,9 @@ def get_pbc_distances(pos, edge_index, cell, cell_offsets, neighbors, cutoff):
     # compute distances
     distances = distance_vectors.norm(dim=-1)
 
+    # redundancy: remove zero distances
+    nonzero_idx = torch.nonzero(distances).flatten()
+    edge_index = edge_index[:, nonzero_idx]
+    distances = distances[nonzero_idx]
+
     return edge_index, distances

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -319,17 +319,4 @@ def get_pbc_distances(pos, edge_index, cell, cell_offsets, neighbors, cutoff):
     # compute distances
     distances = distance_vectors.norm(dim=-1)
 
-    # remove zero distances
-    nonzero_idx = torch.nonzero(distances).flatten()
-    edge_index = edge_index[:, nonzero_idx]
-    distances = distances[nonzero_idx]
-
-    # Some edges have inconsistent distances b/w pymatgen and ase. pymatgen
-    # thinks they're less than the cutoff radius, but not ase. They're about
-    # 0.01% of all remaining edges after the above steps. Manually remove these.
-    # TODO: get rid of this whenever we figure out pymatgen / ase inconsistency.
-    small_idx = torch.nonzero(distances < cutoff).flatten()
-    edge_index = edge_index[:, small_idx]
-    distances = distances[small_idx]
-
     return edge_index, distances

--- a/ocpmodels/datasets/trajectory_lmdb.py
+++ b/ocpmodels/datasets/trajectory_lmdb.py
@@ -23,10 +23,10 @@ class TrajectoryLmdbDataset(Dataset):
 
         self.db_paths = glob.glob(
             os.path.join(self.config["src"], "") + "*lmdb"
-        )[:60]
+        )
         self.txt_paths = glob.glob(
             os.path.join(self.config["src"], "") + "*txt"
-        )[:60]
+        )
         assert len(self.db_paths) > 0, "No LMDBs found in {}".format(
             self.config["src"]
         )

--- a/ocpmodels/datasets/trajectory_lmdb.py
+++ b/ocpmodels/datasets/trajectory_lmdb.py
@@ -23,10 +23,10 @@ class TrajectoryLmdbDataset(Dataset):
 
         self.db_paths = glob.glob(
             os.path.join(self.config["src"], "") + "*lmdb"
-        )
+        )[:60]
         self.txt_paths = glob.glob(
             os.path.join(self.config["src"], "") + "*txt"
-        )
+        )[:60]
         assert len(self.db_paths) > 0, "No LMDBs found in {}".format(
             self.config["src"]
         )
@@ -132,14 +132,8 @@ class TrajSampler(Sampler):
 def data_list_collater(data_list):
     n_neighbors = []
     for i, data in enumerate(data_list):
-        pad_idx = torch.nonzero(data.edge_index[1, :] != -1).flatten()
-        n_neighbors.append(pad_idx.shape[0])
-        data.edge_index = data.edge_index[:, pad_idx]
-        data.cell_offsets = data.cell_offsets[pad_idx]
-        try:
-            data.distances = data.distances[pad_idx]
-        except Exception:
-            continue
+        n_index = data.edge_index[1, :]
+        n_neighbors.append(n_index.shape[0])
     batch = Batch.from_data_list(data_list)
     batch.neighbors = torch.tensor(n_neighbors)
     return batch

--- a/ocpmodels/preprocessing/atoms_to_graphs.py
+++ b/ocpmodels/preprocessing/atoms_to_graphs.py
@@ -23,15 +23,12 @@ class AtomsToGraphs:
     The AtomsToGraphs class takes in periodic atomic structures in form of ASE atoms objects and converts
     them into graph representations for use in PyTorch. The primary purpose of this class is to determine the
     nearest neighbors within some radius around each individual atom, taking into account PBC, and set the
-    pair index and distance between atom pairs appropriately. Additionally, arrays are padded because not all atoms
-    have the same number of neighbors. Lastly, atomic properties and the graph information are put into a
-    PyTorch geometric data object for use with PyTorch.
+    pair index and distance between atom pairs appropriately. Lastly, atomic properties and the graph information
+    are put into a PyTorch geometric data object for use with PyTorch.
 
     Args:
         max_neigh (int): Maximum number of neighbors to consider.
         radius (int or float): Cutoff radius in Angstroms to search for neighbors.
-        dummy_distance (int or float): A dummy distance to pad with, should be larger than radius cutoff.
-        dummy_index (int): A dummy index to pad with.
         r_energy (bool): Return the energy with other properties. Default is False, so the energy will not be returned.
         r_forces (bool): Return the forces with other properties. Default is False, so the forces will not be returned.
         r_distances (bool): Return the distances with other properties.
@@ -42,8 +39,6 @@ class AtomsToGraphs:
     Attributes:
         max_neigh (int): Maximum number of neighbors to consider.
         radius (int or float): Cutoff radius in Angstoms to search for neighbors.
-        dummy_distance (int or float): A dummy distance to pad with.
-        dummy_index (int): A dummy index to pad with.
         r_energy (bool): Return the energy with other properties. Default is False, so the energy will not be returned.
         r_forces (bool): Return the forces with other properties. Default is False, so the forces will not be returned.
         r_distances (bool): Return the distances with other properties.
@@ -57,8 +52,6 @@ class AtomsToGraphs:
         self,
         max_neigh=12,
         radius=6,
-        dummy_distance=7,
-        dummy_index=-1,
         r_energy=False,
         r_forces=False,
         r_distances=False,
@@ -66,92 +59,37 @@ class AtomsToGraphs:
     ):
         self.max_neigh = max_neigh
         self.radius = radius
-        self.dummy_distance = dummy_distance
-        self.dummy_index = dummy_index
         self.r_energy = r_energy
         self.r_forces = r_forces
         self.r_distances = r_distances
         self.r_fixed = r_fixed
 
     def _get_neighbors_pymatgen(self, atoms):
-        """Preforms nearest neighbor search and returns split neighbors indices and distances"""
+        """Preforms nearest neighbor search and returns edge index, distances,
+        and cell offsets"""
         struct = AseAtomsAdaptor.get_structure(atoms)
-        # these return jagged arrays meaning certain atoms have more neighbors than others
-        _c_index, n_index, _images, n_distance = struct.get_neighbor_list(
-            r=self.radius
+        _c_index, _n_index, _offsets, n_distance = struct.get_neighbor_list(
+            r=self.radius, numerical_tol=0, exclude_self=True
         )
-        # find the delimiters, the number of neighbors varies
-        delim = np.where(np.diff(_c_index))[0] + 1
-        # split the neighbor index, distance, lattice offsets based on delimiter
-        split_n_index = np.split(n_index, delim)
-        split_n_distances = np.split(n_distance, delim)
-        split_offsets = np.split(_images, delim)
 
-        return split_n_index, split_n_distances, split_offsets
+        return _c_index, _n_index, n_distance, _offsets
 
-    def _pad_arrays(
-        self, atoms, split_n_index, split_n_distances, split_offsets
-    ):
-        """Pads arrays to standardize the length"""
-        # c_index is the center index, the atom to find the neighbors of
-        c_index = np.arange(0, len(atoms), 1)
-        # pad c_index
-        pad_c_index = np.repeat(c_index, self.max_neigh)
-        # add dummy variables to desired array length
-        pad_n_index = np.full((len(atoms), self.max_neigh), self.dummy_index)
-        pad_distances = np.full(
-            (len(atoms), self.max_neigh), float(self.dummy_distance)
-        )
-        pad_offsets = np.zeros((len(atoms), self.max_neigh, 3), dtype=np.int)
-
-        # loop over the stucture and replace dummy variables where values exist
-        for i, (n_index, distances, offsets) in enumerate(
-            zip(split_n_index, split_n_distances, split_offsets)
-        ):
-            if len(distances) == self.max_neigh:
-                pad_n_index[i] = n_index
-                pad_distances[i] = distances
-                pad_offsets[i] = offsets
-                continue
-            # padding arrays
-            elif len(distances) < self.max_neigh:
-                n_len = len(distances)
-                # potentially add if n_len == 0: print (increase radius)
-                pad_n_index[i][:n_len] = n_index
-                pad_distances[i][:n_len] = distances
-                pad_offsets[i][:n_len] = offsets
-                continue
-            # removing extra values so the length is equal to max_neigh
-            # values are sorted by distance so only nearest neighbors are kept
-            elif len(distances) > self.max_neigh:
-                # this sorts the list min -> max and returns the indices
-                sorted_dist_i = np.argsort(distances)
-                pad_n_index[i] = n_index[sorted_dist_i[: self.max_neigh]]
-                pad_distances[i] = distances[sorted_dist_i[: self.max_neigh]]
-                pad_offsets[i] = offsets[sorted_dist_i[: self.max_neigh]]
-        return pad_c_index, pad_n_index, pad_distances, pad_offsets
-
-    def _reshape_features(
-        self, pad_c_index, pad_n_index, pad_distances, pad_offsets
-    ):
-        """Processes the center and neighbor index and reshapes distances,
+    def _reshape_features(self, c_index, n_index, n_distance, offsets):
+        """Stack center and neighbor index and reshapes distances,
         takes in np.arrays and returns torch tensors"""
-        # edge_index reshape, combine, and define in torch
-        pad_n_index = pad_n_index.reshape(
-            (pad_n_index.shape[0] * pad_n_index.shape[1],)
-        )
-        edge_index = torch.LongTensor([pad_c_index, pad_n_index])
-        # reshape distance to match indices
-        pad_distances = pad_distances.reshape(
-            (pad_distances.shape[0] * pad_distances.shape[1],)
-        )
-        all_distances = torch.Tensor(pad_distances)
-        # reshape offsets to match indices
-        pad_offsets = pad_offsets.reshape(
-            (pad_offsets.shape[0] * pad_offsets.shape[1], -1)
-        )
-        cell_offsets = torch.LongTensor(pad_offsets)
-        return edge_index, all_distances, cell_offsets
+        edge_index = torch.LongTensor(np.vstack((c_index, n_index)))
+        edge_distances = torch.FloatTensor(n_distance)
+        cell_offsets = torch.LongTensor(offsets)
+
+        # remove distances smaller than a tolerance ~ 0. The small tolerance is
+        # needed to correct for pymatgen's neighbor_list returning self atoms
+        # in a few edge cases.
+        nonzero = torch.nonzero(edge_distances >= 1e-8).flatten()
+        edge_index = edge_index[:, nonzero]
+        edge_distances = edge_distances[nonzero]
+        cell_offsets = cell_offsets[nonzero]
+
+        return edge_index, edge_distances, cell_offsets
 
     def convert(
         self, atoms,
@@ -169,9 +107,8 @@ class AtomsToGraphs:
 
         # run internal functions to get padded indices and distances
         split_idx_dist = self._get_neighbors_pymatgen(atoms)
-        padded_idx_dist = self._pad_arrays(atoms, *split_idx_dist)
-        edge_index, all_distances, cell_offsets = self._reshape_features(
-            *padded_idx_dist
+        edge_index, edge_distances, cell_offsets = self._reshape_features(
+            *split_idx_dist
         )
 
         # set the atomic numbers, positions, and cell
@@ -198,7 +135,7 @@ class AtomsToGraphs:
             forces = torch.Tensor(atoms.get_forces(apply_constraint=False))
             data.force = forces
         if self.r_distances:
-            data.distances = all_distances
+            data.distances = edge_distances
         if self.r_fixed:
             fixed_idx = torch.zeros(natoms)
             fixed_idx[atoms.constraints[0].index] = 1

--- a/ocpmodels/preprocessing/atoms_to_graphs.py
+++ b/ocpmodels/preprocessing/atoms_to_graphs.py
@@ -50,7 +50,7 @@ class AtomsToGraphs:
 
     def __init__(
         self,
-        max_neigh=12,
+        max_neigh=200,
         radius=6,
         r_energy=False,
         r_forces=False,
@@ -71,6 +71,19 @@ class AtomsToGraphs:
         _c_index, _n_index, _offsets, n_distance = struct.get_neighbor_list(
             r=self.radius, numerical_tol=0, exclude_self=True
         )
+
+        # remove edges larger than max_neighbors
+        _nonmax_idx = np.concatenate(
+            [
+                (_c_index == i).nonzero()[0][: self.max_neigh]
+                for i in range(len(atoms))
+            ]
+        )
+
+        _c_index = _c_index[_nonmax_idx]
+        _n_index = _n_index[_nonmax_idx]
+        n_distance = n_distance[_nonmax_idx]
+        _offsets = _offsets[_nonmax_idx]
 
         return _c_index, _n_index, n_distance, _offsets
 

--- a/scripts/parallel_preprocess_trajectories.py
+++ b/scripts/parallel_preprocess_trajectories.py
@@ -74,21 +74,35 @@ def write_images_to_lmdb(mp_arg):
 
     try:
         traj_idx = random.randrange(0, len(traj_paths))
-        dl, process_samples = read_trajectory_and_extract_features(
+        (
+            dl,
+            process_samples,
+            relaxed_structure,
+            pos_vectors,
+            idx_log,
+        ) = read_trajectory_and_extract_features(
             a2g, traj_paths[traj_idx], sampled_unique_ids
         )
         for i, do in enumerate(dl):
             # filter out images with excessively large forces, if applicable
-            if (
-                torch.max(torch.abs(do.force)).item()
-                <= args.force_filter_threshold
-            ):
-                # subtract off reference energy
+            if torch.max(torch.abs(do.force)).item() <= args.filter:
                 randomid = os.path.splitext(
                     process_samples[i].split(" ")[0].split("/")[4]
                 )[0]
-                do.tags = get_tags(do, randomid)
-                do.y -= adslab_ref[randomid]
+                # add atom tags
+                if args.tags:
+                    do.tags = get_tags(do, randomid)
+                # subtract off reference energy
+                if args.ref_energy:
+                    do.y -= adslab_ref[randomid]
+                # add vector to relaxed structure
+                if args.relax_vector:
+                    do.relax_vector = relaxed_structure - do.pos
+                # adds history of positional vectors
+                if args.pos_history:
+                    do.pos_history = pos_vectors[i]
+                    do.traj_idx = idx_log[i][0]
+                    do.traj_len = idx_log[i][1]
                 txn = db.begin(write=True)
                 txn.put(
                     f"{idx}".encode("ascii"), pickle.dumps(do, protocol=-1)
@@ -105,8 +119,25 @@ def write_images_to_lmdb(mp_arg):
     return sampled_unique_ids, idx
 
 
+def get_pos_vectors(images, idx):
+    "Stores history of positional vector differences between step N and N-1"
+    natoms = len(images[idx])
+    history_size = 5
+    pos_vectors = torch.zeros(history_size, natoms, 3)
+    for i, j in enumerate(range(idx, idx - history_size, -1)):
+        try:
+            assert j >= 1
+            current_pos = images[j].positions
+            previous_pos = images[j - 1].positions
+            pos_vectors[i] = torch.tensor(current_pos - previous_pos)
+        except Exception:
+            break
+    return pos_vectors
+
+
 def read_trajectory_and_extract_features(a2g, traj_path, sampled_unique_ids):
     traj = ase.io.read(traj_path, ":")
+    relaxed_structure = torch.tensor(traj[-1].get_positions())
     traj_len = len(traj)
     # 0.1 heuristic should work fine as long as args.size is greater than
     # 20 * num_trajectories (each trajectory has 200 images on average).
@@ -114,12 +145,22 @@ def read_trajectory_and_extract_features(a2g, traj_path, sampled_unique_ids):
     sample_idx = random.sample(range(traj_len), sample_count)
     process_samples = []
     images = []
+    pos_vectors = []
+    idx_log = []
     for idx in sample_idx:
         uid = "{},{},{}\n".format(traj_path, idx, traj_len)
         if uid not in sampled_unique_ids:
             process_samples.append(uid)
             images.append(traj[idx])
-    return a2g.convert_all(images, disable_tqdm=True), process_samples
+            pos_vectors.append(get_pos_vectors(traj, idx))
+            idx_log.append((idx, traj_len))
+    return (
+        a2g.convert_all(images, disable_tqdm=True),
+        process_samples,
+        relaxed_structure,
+        pos_vectors,
+        idx_log,
+    )
 
 
 def chunk_list(lst, num_splits):
@@ -157,16 +198,24 @@ if __name__ == "__main__":
         help="No. of images in the dataset",
     )
     parser.add_argument(
-        "--force-filter-threshold",
+        "--filter",
         type=float,
         default=1.0e9,
         help="Max force to filter out, default: no filter",
     )
     parser.add_argument(
-        "--adslab-ref",
-        type=str,
-        default="/checkpoint/mshuaibi/mappings/adslab_ref_energies_ocp728k.pkl",
-        help="Path to reference energies, default: None",
+        "--ref-energy", action="store_true", help="Subtract reference energies"
+    )
+    parser.add_argument("--tags", action="store_true", help="Add atom tags")
+    parser.add_argument(
+        "--relax-vector",
+        action="store_true",
+        help="Add vector to relaxed structure",
+    )
+    parser.add_argument(
+        "--pos-history",
+        action="store_true",
+        help="Add history of positional vectors",
     )
 
     args = parser.parse_args()
@@ -176,8 +225,12 @@ if __name__ == "__main__":
         raw_traj_files = f.read().splitlines()
     num_trajectories = len(raw_traj_files)
 
-    with open(os.path.join(args.adslab_ref), "rb") as g:
-        adslab_ref = pickle.load(g)
+    if args.ref_energy:
+        ref_path = (
+            "/checkpoint/mshuaibi/mappings/adslab_ref_energies_ocp728k.pkl"
+        )
+        with open(os.path.join(ref_path), "rb") as g:
+            adslab_ref = pickle.load(g)
 
     with open(
         "/checkpoint/mshuaibi/mappings/sysid_to_bulkads_dir.pkl", "rb"
@@ -191,10 +244,8 @@ if __name__ == "__main__":
 
     # Initialize feature extractor.
     a2g = AtomsToGraphs(
-        max_neigh=12,
+        max_neigh=200,
         radius=6,
-        dummy_distance=7,
-        dummy_index=-1,
         r_energy=True,
         r_forces=True,
         r_distances=False,

--- a/tests/models/test_cgcnn.py
+++ b/tests/models/test_cgcnn.py
@@ -19,10 +19,8 @@ def load_data(request):
         format="json",
     )
     a2g = AtomsToGraphs(
-        max_neigh=12,
+        max_neigh=200,
         radius=6,
-        dummy_distance=7,
-        dummy_index=-1,
         r_energy=True,
         r_forces=True,
         r_distances=True,

--- a/tests/models/test_dimenet.py
+++ b/tests/models/test_dimenet.py
@@ -19,10 +19,8 @@ def load_data(request):
         format="json",
     )
     a2g = AtomsToGraphs(
-        max_neigh=12,
+        max_neigh=200,
         radius=6,
-        dummy_distance=7,
-        dummy_index=-1,
         r_energy=True,
         r_forces=True,
         r_distances=True,

--- a/tests/models/test_schnet.py
+++ b/tests/models/test_schnet.py
@@ -19,10 +19,8 @@ def load_data(request):
         format="json",
     )
     a2g = AtomsToGraphs(
-        max_neigh=12,
+        max_neigh=200,
         radius=6,
-        dummy_distance=7,
-        dummy_index=-1,
         r_energy=True,
         r_forces=True,
         r_distances=True,

--- a/tests/preprocessing/test_atoms_to_graphs.py
+++ b/tests/preprocessing/test_atoms_to_graphs.py
@@ -4,6 +4,7 @@ import ase
 import numpy as np
 import pytest
 from ase.io import read
+from ase.neighborlist import NeighborList, NewPrimitiveNeighborList
 from pymatgen.io.ase import AseAtomsAdaptor
 
 from ocpmodels.preprocessing import AtomsToGraphs
@@ -17,13 +18,7 @@ def atoms_to_graphs_internals(request):
         format="json",
     )
     test_object = AtomsToGraphs(
-        max_neigh=12,
-        radius=6,
-        dummy_distance=7,
-        dummy_index=-1,
-        r_energy=True,
-        r_forces=True,
-        r_distances=True,
+        max_neigh=12, radius=6, r_energy=True, r_forces=True, r_distances=True,
     )
     request.cls.atg = test_object
     request.cls.atoms = atoms
@@ -34,72 +29,58 @@ class TestAtomsToGraphs:
     def test_gen_neighbors_pymatgen(self):
         # call the internal function
         (
-            split_n_index,
-            split_n_distances,
-            split_offsets,
+            c_index,
+            n_index,
+            n_distances,
+            offsets,
         ) = self.atg._get_neighbors_pymatgen(self.atoms)
-        act_struct = AseAtomsAdaptor.get_structure(self.atoms)
-        # use the old pymatgen method to get distance and indicies
-        act_neigh = act_struct.get_all_neighbors(r=self.atg.radius)
-        # randomly chose to check the neighbors and index of atom 4
-        _, distances, indices, _ = zip(*act_neigh[4])
-        act_dist = np.sort(distances)
-        act_index = np.sort(indices)
-        test_dist = np.sort(split_n_distances[4])
-        test_index = np.sort(split_n_index[4])
+        edge_index, edge_distances, cell_offsets = self.atg._reshape_features(
+            c_index, n_index, n_distances, offsets
+        )
+
+        # use ase to compare distances and indices
+        n = NeighborList(
+            cutoffs=[self.atg.radius / 2.0] * len(self.atoms),
+            self_interaction=False,
+            skin=0,
+            bothways=True,
+            primitive=NewPrimitiveNeighborList,
+        )
+        n.update(self.atoms)
+        ase_neighbors = [
+            n.get_neighbors(index) for index in range(len(self.atoms))
+        ]
+        ase_s_index = []
+        ase_n_index = []
+        ase_offsets = []
+        for i, n in enumerate(ase_neighbors):
+            nidx = n[0]
+            ncount = len(nidx)
+            ase_s_index += [i] * ncount
+            ase_n_index += nidx.tolist()
+            ase_offsets.append(n[1])
+        ase_s_index = np.array(ase_s_index)
+        ase_n_index = np.array(ase_n_index)
+        ase_offsets = np.concatenate(np.array(ase_offsets))
+        # compute ase distance
+        cell = self.atoms.cell
+        positions = self.atoms.positions
+        distance_vec = positions[ase_s_index] - positions[ase_n_index]
+        _offsets = np.dot(ase_offsets, cell)
+        distance_vec -= _offsets
+        act_dist = np.linalg.norm(distance_vec, axis=-1)
+
+        act_dist = np.sort(act_dist)
+        act_index = np.sort(ase_n_index)
+        test_dist = np.sort(edge_distances)
+        test_index = np.sort(edge_index[1, :])
         # check that the distance and neighbor index values are correct
         np.testing.assert_allclose(act_dist, test_dist)
         np.testing.assert_array_equal(act_index, test_index)
-        # check for the correct length
-        # the number of neighbors varies so hard to test that
-        act_len = len(self.atoms)
-        len_dist = len(split_n_distances)
-        len_index = len(split_n_index)
-        np.testing.assert_equal(act_len, len_dist)
-        np.testing.assert_equal(act_len, len_index)
-
-    def test_pad_arrays(self):
-        # call internal functions
-        split_idx_dist = self.atg._get_neighbors_pymatgen(self.atoms)
-        (
-            pad_c_index,
-            pad_n_index,
-            pad_distances,
-            pad_offsets,
-        ) = self.atg._pad_arrays(self.atoms, *split_idx_dist)
-        # check the shape to ensure padding
-        act_shape = (len(self.atoms), self.atg.max_neigh)
-        index_shape = pad_n_index.shape
-        dist_shape = pad_distances.shape
-        np.testing.assert_equal(act_shape, index_shape)
-        np.testing.assert_equal(act_shape, dist_shape)
-
-    def test_reshape_features(self):
-        # call internal functions
-        split_idx_dist = self.atg._get_neighbors_pymatgen(self.atoms)
-        padded_idx_dist = self.atg._pad_arrays(self.atoms, *split_idx_dist)
-        edge_index, all_distances, cell_offsets = self.atg._reshape_features(
-            *padded_idx_dist
-        )
-        # check the shapes of various tensors
-        # combining c_index and n_index for edge_index
-        # 2 arrays of length len(self.atoms) * self.atg.max_neigh
-        act_edge_index_shape = (2, len(self.atoms) * self.atg.max_neigh)
-        edge_index_shape = edge_index.size()
-        np.testing.assert_equal(act_edge_index_shape, edge_index_shape)
-        # check all_distances
-        act_all_distances_shape = (len(self.atoms) * self.atg.max_neigh,)
-        all_distances_shape = all_distances.size()
-        np.testing.assert_equal(act_all_distances_shape, all_distances_shape)
 
     def test_convert(self):
         # run convert on a single atoms obj
         data = self.atg.convert(self.atoms)
-        # check shape/values of features
-        # edge index
-        act_edge_index_shape = (2, len(self.atoms) * self.atg.max_neigh)
-        edge_index_shape = data.edge_index.size()
-        np.testing.assert_equal(act_edge_index_shape, edge_index_shape)
         # atomic numbers
         act_atomic_numbers = self.atoms.get_atomic_numbers()
         atomic_numbers = data.atomic_numbers.numpy()
@@ -116,10 +97,6 @@ class TestAtomsToGraphs:
         act_forces = self.atoms.get_forces(apply_constraint=False)
         forces = data.force.numpy()
         np.testing.assert_allclose(act_forces, forces)
-        # distances
-        act_distances_shape = (len(self.atoms) * self.atg.max_neigh,)
-        distances_shape = data.distances.size()
-        np.testing.assert_equal(act_distances_shape, distances_shape)
 
     def test_convert_all(self):
         # run convert_all on a list with one atoms object
@@ -127,10 +104,6 @@ class TestAtomsToGraphs:
         atoms_list = [self.atoms]
         data_list = self.atg.convert_all(atoms_list)
         # check shape/values of features
-        # edge index
-        act_edge_index_shape = (2, len(self.atoms) * self.atg.max_neigh)
-        edge_index_shape = data_list[0].edge_index.size()
-        np.testing.assert_equal(act_edge_index_shape, edge_index_shape)
         # atomic numbers
         act_atomic_nubmers = self.atoms.get_atomic_numbers()
         atomic_numbers = data_list[0].atomic_numbers.numpy()
@@ -147,7 +120,3 @@ class TestAtomsToGraphs:
         act_forces = self.atoms.get_forces(apply_constraint=False)
         forces = data_list[0].force.numpy()
         np.testing.assert_allclose(act_forces, forces)
-        # distances
-        act_distances_shape = (len(self.atoms) * self.atg.max_neigh,)
-        distances_shape = data_list[0].distances.size()
-        np.testing.assert_equal(act_distances_shape, distances_shape)

--- a/tests/preprocessing/test_atoms_to_graphs.py
+++ b/tests/preprocessing/test_atoms_to_graphs.py
@@ -18,7 +18,11 @@ def atoms_to_graphs_internals(request):
         format="json",
     )
     test_object = AtomsToGraphs(
-        max_neigh=12, radius=6, r_energy=True, r_forces=True, r_distances=True,
+        max_neigh=200,
+        radius=6,
+        r_energy=True,
+        r_forces=True,
+        r_distances=True,
     )
     request.cls.atg = test_object
     request.cls.atoms = atoms

--- a/tests/preprocessing/test_pbc.py
+++ b/tests/preprocessing/test_pbc.py
@@ -19,13 +19,7 @@ def load_data(request):
         format="json",
     )
     a2g = AtomsToGraphs(
-        max_neigh=12,
-        radius=6,
-        dummy_distance=7,
-        dummy_index=-1,
-        r_energy=True,
-        r_forces=True,
-        r_distances=True,
+        max_neigh=12, radius=6, r_energy=True, r_forces=True, r_distances=True,
     )
     data_list = a2g.convert_all([atoms])
     request.cls.data = data_list[0]


### PR DESCRIPTION
@wood-b @abhshkdz and I didn't find a need for dummy indices. We were actually deleting them downstream in our dataloaders/they were causing us issues in the pbc implementation. Let us know if there was a reason to have them at all, otherwise this PR returns them in variable neighbor lengths which isn't a problem for PyG.

@abhshkdz Thoughts on breaking this PR into 2? This current PR would lead to old datasets being inaccurate in their training schemes (with pbc). We can merge this for preprocess refactor until I generate a new batch and then add the dataloader/pbc calculation bits.