### PR TITLE
PBC QOL

### DIFF
--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -307,7 +307,13 @@ def save_experiment_log(args, jobs, configs):
 
 
 def get_pbc_distances(
-    pos, edge_index, cell, cell_offsets, neighbors, return_offsets=False,
+    pos,
+    edge_index,
+    cell,
+    cell_offsets,
+    neighbors,
+    return_offsets=False,
+    return_distance_vec=False,
 ):
     row, col = edge_index
 
@@ -322,11 +328,19 @@ def get_pbc_distances(
     distances = distance_vectors.norm(dim=-1)
 
     # redundancy: remove zero distances
-    nonzero_idx = torch.nonzero(distances).flatten()
+    nonzero_idx = torch.arange(len(distances))[distances != 0]
     edge_index = edge_index[:, nonzero_idx]
     distances = distances[nonzero_idx]
 
-    if return_offsets:
-        return edge_index, distances, offsets
+    if return_distance_vec:
+        distance_vec = distance_vectors[nonzero_idx]
+        if return_offsets:
+            return edge_index, distances, distance_vec, offsets
+        else:
+            return edge_index, distances, distance_vec
+
     else:
-        return edge_index, distances
+        if return_offsets:
+            return edge_index, distances, offsets
+        else:
+            return edge_index, distances

--- a/ocpmodels/common/utils.py
+++ b/ocpmodels/common/utils.py
@@ -332,15 +332,15 @@ def get_pbc_distances(
     edge_index = edge_index[:, nonzero_idx]
     distances = distances[nonzero_idx]
 
-    if return_distance_vec:
-        distance_vec = distance_vectors[nonzero_idx]
-        if return_offsets:
-            return edge_index, distances, distance_vec, offsets
-        else:
-            return edge_index, distances, distance_vec
+    out = {
+        "edge_index": edge_index,
+        "distances": distances,
+    }
 
-    else:
-        if return_offsets:
-            return edge_index, distances, offsets
-        else:
-            return edge_index, distances
+    if return_distance_vec:
+        out["distance_vec"] = distance_vectors[nonzero_idx]
+
+    if return_offsets:
+        out["offsets"] = offsets
+
+    return out

--- a/ocpmodels/datasets/trajectory_lmdb.py
+++ b/ocpmodels/datasets/trajectory_lmdb.py
@@ -98,7 +98,7 @@ class TrajectoryLmdbDataset(Dataset):
             readonly=True,
             lock=False,
             readahead=False,
-            map_size=1099511627776 * 2,
+            map_size=1099511627776 / len(self.db_paths),
         )
         return env
 
@@ -106,7 +106,7 @@ class TrajectoryLmdbDataset(Dataset):
 class TrajSampler(Sampler):
     "Randomly samples batches of trajectories"
 
-    def __init__(self, data_source, traj_per_batch=5):
+    def __init__(self, data_source, traj_per_batch):
         self.data_source = data_source
         self.system_samples = data_source._system_samples
         self.systemids = list(self.system_samples.keys())

--- a/ocpmodels/models/cgcnn.py
+++ b/ocpmodels/models/cgcnn.py
@@ -73,13 +73,16 @@ class CGCNN(BaseModel):
             pos = pos.requires_grad_(True)
 
         if self.use_pbc:
-            data.edge_index, data.edge_weight = get_pbc_distances(
+            out = get_pbc_distances(
                 pos,
                 data.edge_index,
                 data.cell,
                 data.cell_offsets,
                 data.neighbors,
             )
+
+            data.edge_index = out["edge_index"]
+            data.edge_weight = out["distances"]
         else:
             data.edge_index = radius_graph(
                 data.pos, r=self.cutoff, batch=data.batch

--- a/ocpmodels/models/dimenet.py
+++ b/ocpmodels/models/dimenet.py
@@ -1,9 +1,10 @@
 import torch
-from ocpmodels.common.registry import registry
-from ocpmodels.common.utils import get_pbc_distances
 from torch import nn
 from torch_geometric.nn import DimeNet, radius_graph
 from torch_scatter import scatter
+
+from ocpmodels.common.registry import registry
+from ocpmodels.common.utils import get_pbc_distances
 
 
 @registry.register_model("dimenet")
@@ -57,7 +58,7 @@ class DimeNetWrap(DimeNet):
         batch = data.batch
         x = self.embedding(data.atomic_numbers.long())
         if self.use_pbc:
-            edge_index, dist, offsets = get_pbc_distances(
+            out = get_pbc_distances(
                 pos,
                 data.edge_index,
                 data.cell,
@@ -65,6 +66,11 @@ class DimeNetWrap(DimeNet):
                 data.neighbors,
                 return_offsets=True,
             )
+
+            edge_index = out["edge_index"]
+            dist = out["distances"]
+            offsets = out["offsets"]
+
             j, i = edge_index
         else:
             edge_index = radius_graph(pos, r=self.cutoff, batch=batch)

--- a/ocpmodels/models/schnet.py
+++ b/ocpmodels/models/schnet.py
@@ -43,13 +43,16 @@ class SchNetWrap(SchNet):
         if self.use_pbc:
             assert z.dim() == 1 and z.dtype == torch.long
 
-            edge_index, edge_weight = get_pbc_distances(
+            out = get_pbc_distances(
                 pos,
                 data.edge_index,
                 data.cell,
                 data.cell_offsets,
                 data.neighbors,
             )
+
+            edge_index = out["edge_index"]
+            edge_weight = out["distances"]
             edge_attr = self.distance_expansion(edge_weight)
 
             h = self.embedding(z)


### PR DESCRIPTION
For compatibility with @weihua916's codebase:

- Replaces .nonzero() warning with alternative logic to avoid warnings in torch 1.6
- Returns distance vector in `get_pbc_distances`
- Resolves lmdb memory issue

@abhshkdz To get @weihua916 up and going for the new dataset. The `return` statements in `get_pbc_distances` looks messy now, if you have a better way to do this please enlighten me. 