### PR TITLE
Fixes bug in computing angles in DimeNet

### DIFF
--- a/configs/ocp_s2ef/dimenet.yml
+++ b/configs/ocp_s2ef/dimenet.yml
@@ -17,7 +17,7 @@ optim:
   num_workers: 64
   lr_initial: 0.0001
   lr_gamma: 0.1
-  num_gps: 8
+  num_gpus: 8
   lr_milestones: # epochs at which lr_initial <- lr_initial * lr_gamma
     - 5
     - 8


### PR DESCRIPTION
The [pytorch geometric implementation](https://github.com/rusty1s/pytorch_geometric/blob/master/torch_geometric/nn/models/dimenet.py#L445) looks incorrect to me.

For a triplet from `i` to `j` to `k`, the two vectors we should be considering when computing angles are `i—>j` and `j—>k` and not `i—>j` and `i—>k`. Let me know if that doesn't make sense.