### PR TITLE
save prediction files in format for evalAI

### DIFF
--- a/configs/ocp_is2rs/base.yml
+++ b/configs/ocp_is2rs/base.yml
@@ -26,6 +26,7 @@ task:
   # Relaxation options
   relax_dataset:
     src: data/09_29_val_is2rs_lmdb
+  write_pos: True
   relaxation_steps: 300
   relax_opt:
     maxstep: 300

--- a/main.py
+++ b/main.py
@@ -45,15 +45,21 @@ def main(config):
             trainer.train()
 
         elif config["mode"] == "predict":
-            assert trainer.test_loader is not None, "Test dataset is required for making predictions"
+            assert (
+                trainer.test_loader is not None
+            ), "Test dataset is required for making predictions"
             assert config["checkpoint"]
             run_dir = config.get("run_dir", "./")
-            results_file = Path(run_dir) / "predictions.txt"
+            results_file = Path(run_dir) / "predictions.json"
             trainer.predict(trainer.test_loader, results_file=results_file)
 
         elif config["mode"] == "run_relaxations":
-            assert isinstance(trainer, ForcesTrainer), "Relaxations are only possible for ForcesTrainer"
-            assert trainer.relax_dataset is not None, "Relax dataset is required for making predictions"
+            assert isinstance(
+                trainer, ForcesTrainer
+            ), "Relaxations are only possible for ForcesTrainer"
+            assert (
+                trainer.relax_dataset is not None
+            ), "Relax dataset is required for making predictions"
             assert config["checkpoint"]
             trainer.validate_relaxation()
 

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -249,7 +249,13 @@ class ForcesTrainer(BaseTrainer):
 
     # Takes in a new data source and generates predictions on it.
     def predict(self, data_loader, per_image=True, results_file=None):
-        assert isinstance(data_loader, (torch.utils.data.dataloader.DataLoader, torch_geometric.data.Batch))
+        assert isinstance(
+            data_loader,
+            (
+                torch.utils.data.dataloader.DataLoader,
+                torch_geometric.data.Batch,
+            ),
+        )
 
         if isinstance(data_loader, torch_geometric.data.Batch):
             data_loader = [[data_loader]]
@@ -291,9 +297,14 @@ class ForcesTrainer(BaseTrainer):
 
         if results_file is not None:
             print(f"Writing results to {results_file}")
-            # TODO: Write in correct format for EvalAI
+            # EvalAI expects a list of dicts with energy and forces
+            evalAI_results = []
+            for energy, forces in predictions["energy"], predictions["forces"]:
+                evalAI_results.append(
+                    {"energy": energy, "forces": forces.tolist()}
+                )
             with open(results_file, "w") as resfile:
-                print(predictions, file=resfile)
+                json.dump(evalAI_results, resfile)
 
         return predictions
 

--- a/scripts/make_evalai_json.py
+++ b/scripts/make_evalai_json.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
 
     S2EF: config["mode"] = "predict"
     IS2RE: config["mode"] = "predict"
-    IS2RS: config["mode"] = "predict and "config["task"]["write_pos"] = True
+    IS2RS: config["mode"] = "run_relaxations" and config["task"]["write_pos"] = True
 
     Use this script to join the 4 results files in the format evalAI expects
     submissions.

--- a/scripts/make_evalai_json.py
+++ b/scripts/make_evalai_json.py
@@ -5,7 +5,7 @@ import os
 def main(paths, filename, data_split="val"):
     submission_file = {}
 
-    for idx, split in enumerate(["id", "ood_ads", "ood_bulk", "ood_ads_bulk"]):
+    for idx, split in enumerate(["id", "ood_ads", "ood_cat", "ood_both"]):
         key = "_".join([data_split, split])
         submission_file[key] = json.load(open(os.path.join(paths[idx]), "r"))
 
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     """
     Create a submission file for evalAI. Ensure that for the task you are
     submitting for you have generated results files on each of the 4 splits -
-    id, ood_ads, ood_bulk, ood_ads_bulk.
+    id, ood_ads, ood_cat, ood_both.
 
     Results file can be obtained as follows for the various tasks:
 
@@ -31,9 +31,9 @@ if __name__ == "__main__":
 
     id_path = "/path/to/id/results_file"
     ood_ads_path = "/path/to/ood_ads/results_file"
-    ood_bulk_path = "/path/to/ood_bulk/results_file"
-    ood_ads_bulk_path = "/path/to/ood_ads_bulk/results_file"
+    ood_cat_path = "/path/to/ood_cat/results_file"
+    ood_both_path = "/path/to/ood_both/results_file"
 
-    paths = [id_path, ood_ads_path, ood_bulk_path, ood_ads_bulk_path]
+    paths = [id_path, ood_ads_path, ood_cat_path, ood_both_path]
 
     main(paths, filename="TASKNAME_evalai_submission.json", data_split="val")

--- a/scripts/make_evalai_json.py
+++ b/scripts/make_evalai_json.py
@@ -1,0 +1,39 @@
+import json
+import os
+
+
+def main(paths, filename, data_split="val"):
+    submission_file = {}
+
+    for idx, split in enumerate(["id", "ood_ads", "ood_bulk", "ood_ads_bulk"]):
+        key = "_".join([data_split, split])
+        submission_file[key] = json.load(open(os.path.join(paths[idx]), "r"))
+
+    with open(filename, "w") as f:
+        json.dump(submission_file, f)
+
+
+if __name__ == "__main__":
+    """
+    Create a submission file for evalAI. Ensure that for the task you are
+    submitting for you have generated results files on each of the 4 splits -
+    id, ood_ads, ood_bulk, ood_ads_bulk.
+
+    Results file can be obtained as follows for the various tasks:
+
+    S2EF: config["mode"] = "predict"
+    IS2RE: config["mode"] = "predict"
+    IS2RS: config["mode"] = "predict and "config["task"]["write_pos"] = True
+
+    Use this script to join the 4 results files in the format evalAI expects
+    submissions.
+    """
+
+    id_path = "/path/to/id/results_file"
+    ood_ads_path = "/path/to/ood_ads/results_file"
+    ood_bulk_path = "/path/to/ood_bulk/results_file"
+    ood_ads_bulk_path = "/path/to/ood_ads_bulk/results_file"
+
+    paths = [id_path, ood_ads_path, ood_bulk_path, ood_ads_bulk_path]
+
+    main(paths, filename="TASKNAME_evalai_submission.json", data_split="val")

--- a/scripts/merge_pos_evalai.py
+++ b/scripts/merge_pos_evalai.py
@@ -1,0 +1,48 @@
+import json
+import os
+
+
+def main(jsons, dft_ref_trajs, out_path):
+    id2pos = {}
+    ids = []
+    for i in jsons:
+        d = json.load(open(i, "r"))
+        for j in d:
+            ids.append(j[0])
+            if j[0] in id2pos:
+                print("repeat", j[0])
+                pass
+            else:
+                id2pos[j[0]] = j[1]
+    with open(dft_ref_trajs, "r") as f:
+        randomids = f.read().splitlines()
+    randomids = [os.path.split(i)[-1].split(".")[0] for i in randomids]
+    n = len(id2pos)
+    print("total", n)
+    preds = []
+    for i in range(n):
+        preds.append(
+            {
+                "simulation_id": randomids[i],
+                "positions": id2pos[i],
+            }
+        )
+    print("Saving to", out_path)
+    json.dump(preds, open(out_path, "w"))
+
+
+if __name__ == "__main__":
+    """
+    If relaxations run in a multi-GPU configuration, merge
+    relaxed_pos_[DEVICE #] json files into a single json file in the correct
+    ordering necessary for evalAI.
+    """
+
+    jsons = [
+        "PATH/TO/relaxed_pos_0.json",
+        "PATH/TO/relaxed_pos_2.json",
+        "PATH/TO/relaxed_pos_3.json",
+    ]
+
+    dft_ref_trajs = "PATH/TO/split_txt_file_with_ids"
+    out_path = "relaxed_pos_full.json"


### PR DESCRIPTION
Modifies the prediction files created by `.predict()` call in a format compatible with json. Because prediction files are created independently, a separate script is included to join the separate files to be submitted to evalAI directly.