### PR TITLE
more consistent naming

### DIFF
--- a/ocpmodels/common/relaxation/ml_relaxation.py
+++ b/ocpmodels/common/relaxation/ml_relaxation.py
@@ -8,18 +8,17 @@ from ocpmodels.common.registry import registry
 from .optimizers.lbfgs_torch import LBFGS, TorchCalc
 
 
-def relax_eval(
+def ml_relax(
     batch,
     model,
     steps,
     fmax,
     relax_opt,
-    return_relaxed_pos,
     device="cuda:0",
     transform=None,
 ):
     """
-    Evaluation of ML-based relaxations.
+    Runs ML-based relaxations.
     Args:
         batch: object
         model: object
@@ -30,9 +29,6 @@ def relax_eval(
             of the system is no bigger than fmax.
         relax_opt: str
             Optimizer and corresponding parameters to be used for structure relaxations.
-        return_relaxed_pos: bool
-            Whether to return relaxed positions to be written for dft
-            evaluation.
     """
     batch = batch[0]
     ids = batch.id

--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -14,7 +14,7 @@ from ocpmodels.common import distutils
 from ocpmodels.common.data_parallel import OCPDataParallel, ParallelCollater
 from ocpmodels.common.meter import Meter
 from ocpmodels.common.registry import registry
-from ocpmodels.common.relaxation.eval_relaxation import relax_eval
+from ocpmodels.common.relaxation.ml_relaxation import ml_relax
 from ocpmodels.common.utils import plot_histogram, save_checkpoint
 from ocpmodels.modules.evaluator import Evaluator
 from ocpmodels.modules.normalizer import Normalizer
@@ -495,12 +495,11 @@ class ForcesTrainer(BaseTrainer):
 
         relaxed_positions = []
         for i, batch in enumerate(self.relax_loader):
-            relaxed_batch = relax_eval(
+            relaxed_batch = ml_relax(
                 batch=batch,
                 model=self,
                 steps=self.config["task"].get("relaxation_steps", 200),
                 fmax=self.config["task"].get("relaxation_fmax", 0.0),
-                return_relaxed_pos=self.config["task"].get("write_pos", False),
                 relax_opt=self.config["task"]["relax_opt"],
                 device=self.device,
                 transform=None,


### PR DESCRIPTION
nit - ml relaxation scripts aren't performing "eval" anymore, renamed accordingly. 