### PR TITLE
BUGFIX: broken trainer when val set not specified

### DIFF
--- a/ocpmodels/trainers/forces_trainer.py
+++ b/ocpmodels/trainers/forces_trainer.py
@@ -473,6 +473,21 @@ class ForcesTrainer(BaseTrainer):
                                 },
                                 self.config["cmd"]["checkpoint_dir"],
                             )
+                elif not self.is_debug and distutils.is_master():
+                    save_checkpoint(
+                        {
+                            "epoch": epoch + 1,
+                            "state_dict": self.model.state_dict(),
+                            "optimizer": self.optimizer.state_dict(),
+                            "normalizers": {
+                                key: value.state_dict()
+                                for key, value in self.normalizers.items()
+                            },
+                            "config": self.config,
+                            "metrics": self.metrics,
+                        },
+                        self.config["cmd"]["checkpoint_dir"],
+                    )
 
             if self.test_loader is not None:
                 self.validate(split="test", epoch=epoch)


### PR DESCRIPTION
Energy trainer tries to checkpoint val metrics when val set not specified. Checkpoints every training epoch if no val set is found. We could also just throw an error message saying please specify val set.